### PR TITLE
[feat]: support multiple languages using pelias/spatial

### DIFF
--- a/middleware/changeLanguage.js
+++ b/middleware/changeLanguage.js
@@ -45,6 +45,8 @@ function setup(service, should_execute) {
         response_time: Date.now() - start,
         language: req.clean.lang.iso6391,
         controller: 'language', //technically middleware, but this is consistent with other log lines
+        result_count: _.defaultTo(res.data, []).length,
+        data: translations
       });
 
       // otherwise, update all the docs with translations
@@ -108,12 +110,12 @@ function updateDocs( req, res, translations ){
         }
 
         // translate 'parent.*' property
-        adminValues[i] = translations[id].names[ requestLanguage ][0];
+        adminValues[i] = translations[id].names[ requestLanguage ];
 
         // if the record is an admin record we also translate
         // the 'name.default' property.
         if( adminKey === doc.layer ){
-          doc.name.default = translations[id].names[ requestLanguage ][0];
+          doc.name.default = translations[id].names[ requestLanguage ];
         }
       }
     }

--- a/service/configurations/Language.js
+++ b/service/configurations/Language.js
@@ -30,7 +30,7 @@ class Language extends ServiceConfiguration {
   }
 
   getUrl(req) {
-    return url.resolve(this.baseUrl, 'parser/findbyid');
+    return url.resolve(this.baseUrl, '/placeholder/osm/names');
   }
 
 }


### PR DESCRIPTION
note: change place holder service in pelias.json setting to host of pelias/spatial service to using  language as spatial

    "services": {
      "placeholder": {
        "url": "http://0.0.0.0:3000" -> change to host of spatial
      }